### PR TITLE
Add parenthesis to prevent error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ try:
     doc.markdown = long_description
 
     long_description = doc.rst
-except ImportError, IOError:
+except (ImportError, IOError):
     pass
 
 


### PR DESCRIPTION
I think the syntax for this has changed so parenthesis must be added to prevent an error that prevents installation.
https://www.geeksforgeeks.org/multiple-exception-handling-in-python/